### PR TITLE
Feature/40329

### DIFF
--- a/html/css/style.css
+++ b/html/css/style.css
@@ -205,3 +205,52 @@ summary.buy {
     display: flex;
     flex-direction: row;
 }
+
+
+@media (min-width:992px) {
+    .container {
+        margin-left: 100px;
+        margin-right: 100px;
+    }
+    .paymentblock {
+        flex: 3;
+    }
+    .cartblock {
+        flex: 2;
+    }
+}
+
+@media (max-width:992px) {
+    .container {
+        margin-left: 20px;
+        margin-right: 20px;
+    }
+}
+
+@media screen and (min-width: 768px) and (max-width: 992px) {
+    .paymentblock {
+        flex: 1;
+    }
+    .cartblock {
+        flex: 1;
+    }
+}
+
+@media (max-width:600px) {
+    .block2 {
+        flex-direction: column-reverse;
+    }
+}
+
+@media (max-width: 768px) {
+    .checkout1 {
+        display: none;
+    }
+}
+
+@media (max-width: 400px) {
+    .image {
+        display: flex;
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
**Task**:
Please see the attached GIF for the sample.
1. The margin of the main container must be 100px from left and right if the width is greater than or equal to 992 px.
2. The margin of the main container must be 20px from left and right if the width is less than 992px
3. Payment and Cart section must be 3:2 in ratio if the width is greater than or equal to 992 px.
4. Payment and Cart section must be 1:1 in ratio if the width is greater than or equal to 768 px and less than 992px.
5. Cart Section must come before payment section, if the length is less than 600px, and must acquire entire width.
6. Wallet Images must take entire width of the screen if width falls below 400px.
7. Breadcrumb must not be visible if the width is less than 768px.

